### PR TITLE
Fix URIs in gemspec

### DIFF
--- a/omochi.gemspec
+++ b/omochi.gemspec
@@ -10,14 +10,13 @@ Gem::Specification.new do |spec|
 
   spec.summary = 'Write a short summary, because RubyGems requires one.'
   spec.description = 'Write a longer description or delete this line.'
-  spec.homepage = 'https://github.com/mikik0'
+  spec.homepage = 'https://github.com/mikik0/omochi'
   spec.required_ruby_version = '>= 2.6.0'
 
   spec.metadata['allowed_push_host'] = "TODO: Set to your gem server 'https://example.com'"
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = 'https://github.com/mikik0'
-  spec.metadata['changelog_uri'] = 'https://github.com/mikik0'
+  spec.metadata['source_code_uri'] = 'https://github.com/mikik0/omochi'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
There's no CHANGELOG so `changelog_uri` was removed.