### PR TITLE
change installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ There are two advantages of using Omochi. We can make sure every method is cover
 
 ## Installation
 
-```
-$ gem specific_install -l https://github.com/mikik0/omochi.git
-```
+    $ gem install omochi
 
 ## Usage
 


### PR DESCRIPTION
Since we have published to `https://rubygems.org/`, the Installation method has changed.